### PR TITLE
fix: TypeScriptビルドエラーを修正

### DIFF
--- a/server-gas/src/infrastructure/repositories/s-SheetSummaryRepository.ts
+++ b/server-gas/src/infrastructure/repositories/s-SheetSummaryRepository.ts
@@ -105,13 +105,23 @@ class SheetSummaryRepository implements ISummaryRepository {
         
         runStarts.forEach((startIdx, runIdx) => {
           if (row[startIdx]) {
-            const runKey = runProperties[runIdx] as keyof PageSummary;
-            summary[runKey] = {
+            const runSummary: RunSummary = {
               date: new Date(row[startIdx] as string),
               pageUpdated: row[startIdx + 1] as boolean,
               pdfUpdated: row[startIdx + 2] as boolean,
               addedCount: row[startIdx + 3] as number,
-            } as RunSummary;
+            };
+            
+            // Type-safe assignment
+            switch (runIdx) {
+              case 0: summary.run1 = runSummary; break;
+              case 1: summary.run2 = runSummary; break;
+              case 2: summary.run3 = runSummary; break;
+              case 3: summary.run4 = runSummary; break;
+              case 4: summary.run5 = runSummary; break;
+              case 5: summary.run6 = runSummary; break;
+              case 6: summary.run7 = runSummary; break;
+            }
           }
         });
         


### PR DESCRIPTION
## 概要
server-gasのTypeScriptビルドエラーを修正しました。

## 問題
CI/CDでTypeScriptのビルドエラーが発生：
```
error TS2322: Type 'RunSummary' is not assignable to type 'string & RunSummary'.
```

## 原因
TypeScriptが動的プロパティアクセス`summary[runKey]`の型を正しく推論できない

## 解決策
switch文を使用して明示的に各プロパティに代入するように変更

### 変更前
```typescript
const runKey = runProperties[runIdx] as keyof PageSummary;
summary[runKey] = { ... } as RunSummary;
```

### 変更後
```typescript
const runSummary: RunSummary = { ... };
switch (runIdx) {
  case 0: summary.run1 = runSummary; break;
  case 1: summary.run2 = runSummary; break;
  // ... run7まで
}
```

## 影響
- ロジックの変更なし（純粋に構文的な修正）
- 実行結果は完全に同一
- TypeScriptの型安全性を満たす

## チェックリスト
- [x] ビルドが成功する
- [x] ESLintエラーがない
- [x] 既存の動作に影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)