### PR TITLE
fix: 未使用変数runPropertiesを削除

### DIFF
--- a/server-gas/src/infrastructure/repositories/s-SheetSummaryRepository.ts
+++ b/server-gas/src/infrastructure/repositories/s-SheetSummaryRepository.ts
@@ -101,8 +101,6 @@ class SheetSummaryRepository implements ISummaryRepository {
           SheetSummaryRepository.COLUMN_INDICES.RUN7_START,
         ];
         
-        const runProperties = ['run1', 'run2', 'run3', 'run4', 'run5', 'run6', 'run7'] as const;
-        
         runStarts.forEach((startIdx, runIdx) => {
           if (row[startIdx]) {
             const runSummary: RunSummary = {


### PR DESCRIPTION
## 概要
前回のTypeScript修正により不要になった変数を削除しました。

## 変更内容
- `runProperties`配列が未使用になったため削除
- switch文を使用するようになったため、この配列は不要

## エラー内容
```
'runProperties' is assigned a value but never used
```

## チェックリスト
- [x] ESLintエラーがない
- [x] ビルドが成功する
- [ ] テスト実行予定（GitHub Actions実行後）

🤖 Generated with [Claude Code](https://claude.ai/code)